### PR TITLE
Add human readable message to existing ENOENT error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ function _get(filePath, cb) {
     }
 
     if (err.code === 'ENOENT') {
-      return cb(new Error(`The file in path ${fullPath} doesn\'t exist`), null);
+      err.message = `The file in path ${fullPath} doesn\'t exist`;
     }
 
     return cb(err);


### PR DESCRIPTION
It's useful to have `err.code` available for parsing when the error bubbles up to application error handlers.
Otherwise we would need to parse the human readable message which is messy and may change in future versions.
