### PR TITLE
Add boolean to create new file on enoent

### DIFF
--- a/tests/src/index.spec.js
+++ b/tests/src/index.spec.js
@@ -41,6 +41,16 @@ describe('Electron Storage', () => {
   });
 
   describe('storage.get()', () => {
+    it('creates a new file if none exists and options contains create: true', (done) => {
+      storage.get('my-missing-data.json', {create: true}, (error, data) => {
+        chai.expect(error).to.equal(null);
+        chai.expect(data).to.deep.equal({});
+        done();
+      });
+    });
+  });
+
+  describe('storage.get()', () => {
     it('receives the data from a json file', (done) => {
       const json = JSON.stringify({ awesome: 'data' });
       fs.writeFile(path.join(fakeAppDataDir, 'my-awesome-data.json'), json, (err) => {

--- a/tests/src/index.spec.js
+++ b/tests/src/index.spec.js
@@ -55,6 +55,18 @@ describe('Electron Storage', () => {
   });
 
   describe('storage.get()', () => {
+    it('creates returns data if file exists and options contains create: true', (done) => {
+      storage.set('data.json', {it: 'exists'}, (error) =>{
+        chai.expect(error).to.equal(null);
+        storage.get('data.json', {create: true}, (error, data) => {
+          chai.expect(error).to.equal(null);
+          chai.expect(data).to.deep.equal({it: 'exists'});
+          done();
+        });
+      });
+    });
+  });
+  describe('storage.get()', () => {
     it('receives the data from a json file', (done) => {
       const json = JSON.stringify({ awesome: 'data' });
       fs.writeFile(path.join(fakeAppDataDir, 'my-awesome-data.json'), json, (err) => {

--- a/tests/src/index.spec.js
+++ b/tests/src/index.spec.js
@@ -45,7 +45,11 @@ describe('Electron Storage', () => {
       storage.get('my-missing-data.json', {create: true}, (error, data) => {
         chai.expect(error).to.equal(null);
         chai.expect(data).to.deep.equal({});
-        done();
+        storage.get('my-missing-data.json', (error, data)=>{
+          chai.expect(error).to.equal(null);
+          chai.expect(data).to.deep.equal({});
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
Added an optional options object to the get() call which creates a new file if none exists. 

I wanted to update existing json files with a `storage.get()`, then `storage.set()` but it blows up on the initial pass. 

Example:

```
storage.get('my-nonexistent.json', {create: true}, (err, data) => {
    console.log(data);
});

```

will create the file `my-nonexistent.json` and return `{}` if it doesn't exist.

It returns the file as normal if the file exists. 